### PR TITLE
fix: correct github package registry publishing and send coverage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm run rename @vincegando/priority-queue-node
       - uses: actions/setup-node@v2
         with:
           registry-url: 'https://npm.pkg.github.com'
@@ -25,3 +26,4 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm run rename priority-queue-node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,18 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - run: npm install
       - run: npm test
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.node_version }}-${{ matrix.architecture }}
+          parallel: true
+  post_build:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Post Test
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "tap",
     "lint": "eslint .",
-    "pretest": "npm run lint"
+    "pretest": "npm run lint",
+    "rename": "node rename.js"
   },
   "keywords": [
     "priority",

--- a/rename.js
+++ b/rename.js
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+'use strict'
+
+const writeFileSync = require('fs').writeFileSync
+const pkg = require('./package.json')
+
+function rename(name) {
+  pkg.name = name
+  writeFileSync(process.cwd() + '/package.json', JSON.stringify(pkg, null, 2))
+}
+
+rename(process.argv[2])


### PR DESCRIPTION
in order to publish to both the npm registry and the github registry
under different scopes, a script is required to change the name field
in `package.json` between publish steps. also the test action is
modified to send coverage reports to coveralls.